### PR TITLE
Fix a syntax error in print() function.

### DIFF
--- a/R/mapscape.R
+++ b/R/mapscape.R
@@ -508,9 +508,9 @@ mapscape <- function(clonal_prev,
     
     # warn if more than 10,000 rows in data that the visualization may be slow
     if (nrow(mutation_prevalences) > 10000 && show_warnings) {
-      print("[WARNING] Number of rows in mutations data exceeds 10,000. ",
-        "Resultantly, visualization may be slow. ",
-        "It is recommended to filter the data to a smaller set of mutations.")
+      print(paste0("[WARNING] Number of rows in mutations data exceeds 10,000. ",
+                  "Resultantly, visualization may be slow. ",
+                  "It is recommended to filter the data to a smaller set of mutations."))
     }
 
     # compress results


### PR DESCRIPTION
Dear author, I have found this error information in case of mutation numbers > 10000:

![图片](https://user-images.githubusercontent.com/32410912/81364457-43be2980-9118-11ea-9615-35b7c6d5f311.png)

This error is induced by a syntax error in this part in the script:
![图片](https://user-images.githubusercontent.com/32410912/81365161-0195e780-911a-11ea-8cf1-c54451fab233.png)

The "print()" function can not be used with strings sperated by ",".

This can be fixed like this:
![图片](https://user-images.githubusercontent.com/32410912/81365208-1c685c00-911a-11ea-8266-8ac27420246f.png)
